### PR TITLE
Fix 116 - duplicate handling

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -29,21 +29,21 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             testthat,
             httptest,
             rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/devtools-test.yaml
+++ b/.github/workflows/devtools-test.yaml
@@ -9,9 +9,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 

--- a/.github/workflows/lint-project.yaml
+++ b/.github/workflows/lint-project.yaml
@@ -11,9 +11,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,15 +13,15 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: pkgdown
           needs: website

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Suggests:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 URL: https://github.com/mattroumaya/surveymonkey
 BugReports: https://github.com/mattroumaya/surveymonkey/issues

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -48,7 +48,7 @@ parse_survey <- function(
   # to deal with this add parameter fix_duplicate where default behaviour is to error, but
   # can be set to allow the function to continue and return.
   fix_duplicates <- match.arg(fix_duplicates)
-browser()
+
   if (fix_duplicates == "error") {
     x <- duplicate_error(x)
   } else if (fix_duplicates == "keep") {

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -9,6 +9,9 @@
 #' @param fix_duplicates character if 'error', the default detection of duplicate data will result
 #' in an error being raised, otherwise allow the function to return. If 'keep' duplicate results
 #' will be retained, if 'drop' duplicates will be removed from the results.
+#'
+#' If encountering issues with duplicates, use `fix_duplicates = 'none'` to deal with duplicate responses after
+#' the survey is parsed.
 #' @return a data.frame (technically a \code{tibble}) with clean responses, one line per respondent.
 #' @importFrom rlang .data
 #' @export

--- a/R/assemble.R
+++ b/R/assemble.R
@@ -14,7 +14,7 @@
 #' @export
 parse_survey <- function(
   surv_obj, oauth_token = get_token(), ...,
-  fix_duplicates = c("error", "drop", "keep")
+  fix_duplicates = c("error", "drop", "keep", "none")
 ) {
   . <- NULL
   if (surv_obj$response_count == 0) {
@@ -45,12 +45,15 @@ parse_survey <- function(
   # to deal with this add parameter fix_duplicate where default behaviour is to error, but
   # can be set to allow the function to continue and return.
   fix_duplicates <- match.arg(fix_duplicates)
+browser()
   if (fix_duplicates == "error") {
     x <- duplicate_error(x)
   } else if (fix_duplicates == "keep") {
     x <- duplicate_keep(x)
-  } else {
+  } else if (fix_duplicates == "drop") {
     x <- duplicate_drop(x)
+  } else {
+    x
   }
 
 

--- a/man/parse_survey.Rd
+++ b/man/parse_survey.Rd
@@ -8,7 +8,7 @@ parse_survey(
   surv_obj,
   oauth_token = get_token(),
   ...,
-  fix_duplicates = c("error", "drop", "keep")
+  fix_duplicates = c("error", "drop", "keep", "none")
 )
 }
 \arguments{
@@ -22,7 +22,10 @@ parse_survey(
 
 \item{fix_duplicates}{character if 'error', the default detection of duplicate data will result
 in an error being raised, otherwise allow the function to return. If 'keep' duplicate results
-will be retained, if 'drop' duplicates will be removed from the results.}
+will be retained, if 'drop' duplicates will be removed from the results.
+
+If encountering issues with duplicates, use `fix_duplicates = 'none'` to deal with duplicate responses after
+the survey is parsed.}
 }
 \value{
 a data.frame (technically a \code{tibble}) with clean responses, one line per respondent.

--- a/tests/testthat/test_strip_html.r
+++ b/tests/testthat/test_strip_html.r
@@ -6,8 +6,8 @@ test_that("all <> and values between are removed", {
   expect_equal(
     mtcars %>%
       dplyr::select(
-        "What is your <strong>favorite</strong> color?" = .data$mpg,
-        "Keep <this> value" = .data$cyl
+        "What is your <strong>favorite</strong> color?" = "mpg",
+        "Keep <this> value" = "cyl"
       ) %>%
       strip_html() %>%
       colnames(.),
@@ -22,8 +22,8 @@ test_that("ignore values are kept", {
   expect_equal(
     mtcars %>%
       dplyr::select(
-        "What is your <strong>favorite</strong> color?" = .data$mpg,
-        "Keep <this> value" = .data$cyl
+        "What is your <strong>favorite</strong> color?" = "mpg",
+        "Keep <this> value" = "cyl"
       ) %>%
       strip_html(ignore = "this") %>%
       colnames(.),
@@ -34,8 +34,8 @@ test_that("ignore values are kept", {
 test_that("warning when values are not found", {
   expect_warning(mtcars %>%
     dplyr::select(
-      "What is your <strong>favorite</strong> color?" = .data$mpg,
-      "Keep <this> value" = .data$cyl
+      "What is your <strong>favorite</strong> color?" = "mpg",
+      "Keep <this> value" = "cyl"
     ) %>%
     strip_html(ignore = "not_in_these_columns_satan!") %>%
     colnames(.),
@@ -51,8 +51,8 @@ test_that("trim_space == TRUE is working correctly", {
   expect_equal(
     mtcars %>%
       dplyr::select(
-        "What is your <strong>favorite</strong> color?" = .data$mpg,
-        "Keep <this> value" = .data$cyl
+        "What is your <strong>favorite</strong> color?" = "mpg",
+        "Keep <this> value" = "cyl"
       ) %>%
       strip_html(trim_space = TRUE) %>%
       colnames(.),
@@ -66,8 +66,8 @@ test_that("trim_space == FALSE is working correctly", {
   expect_equal(
     mtcars %>%
       dplyr::select(
-        "What is your <strong>favorite</strong> color?" = .data$mpg,
-        "Keep <this> value" = .data$cyl
+        "What is your <strong>favorite</strong> color?" = "mpg",
+        "Keep <this> value" = "cyl"
       ) %>%
       strip_html(trim_space = FALSE) %>%
       colnames(.),


### PR DESCRIPTION
Adds an option to ignore duplicates entirely and deal with them as-needed after the survey is parsed: 


```r
survey_df <- 123456789 %>%
  fetch_survey_obj %>%
  parse_survey(fix_duplicates = 'none')
```
